### PR TITLE
Debug user id retrieval after gateway and rbac updates

### DIFF
--- a/app/api/first30-signup/route.ts
+++ b/app/api/first30-signup/route.ts
@@ -1,7 +1,7 @@
+import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
 
 import { db } from '../../../database/client';
 import { emailCaptures } from '../../../database/schema';

--- a/app/api/mobile/generate-token/route.ts
+++ b/app/api/mobile/generate-token/route.ts
@@ -2,8 +2,8 @@ import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 
-import { db } from '@/client';
-import { mobileTokens } from '@/schema';
+import { db } from '../../../../database/client';
+import { mobileTokens } from '../../../../database/schema/mobile_tokens';
 
 export async function POST(req: Request) {
   try {

--- a/app/api/patient-sessions/route.ts
+++ b/app/api/patient-sessions/route.ts
@@ -3,8 +3,8 @@ import { and, desc, eq } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { db } from '@/client';
-import { patientSessions } from '@/schema';
+import { db } from '../../../database/client';
+import { patientSessions } from '../../../database/schema/patient_sessions';
 
 // GET - List patient sessions for a user
 export async function GET(req: NextRequest) {

--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -1,6 +1,5 @@
+import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
-
-import { getAuth } from '@/shared/services/auth/clerk';
 
 import { db } from '../../../../database/client';
 import { userSettings } from '../../../../database/schema/user_settings';
@@ -9,38 +8,50 @@ import { userSettings } from '../../../../database/schema/user_settings';
 const DEFAULT_SETTINGS = { templateOrder: [] };
 
 export async function GET() {
-  const { userId } = await getAuth();
+  const { userId } = await auth();
   if (!userId) {
-    return NextResponse.json({ code: 'UNAUTHORIZED', message: 'You must be logged in to access user settings' }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Try to fetch settings
-  let settingsRow = await db.query.userSettings.findFirst({ where: (u, { eq }) => eq(u.userId, userId) });
-  if (!settingsRow) {
-    // Create with defaults if not found
-    await db.insert(userSettings).values({ userId, settings: DEFAULT_SETTINGS });
-    settingsRow = { userId, settings: DEFAULT_SETTINGS, updatedAt: new Date() };
+  try {
+    // Try to fetch settings
+    let settingsRow = await db.query.userSettings.findFirst({ where: (u, { eq }) => eq(u.userId, userId) });
+    if (!settingsRow) {
+      // Create with defaults if not found
+      await db.insert(userSettings).values({ userId, settings: DEFAULT_SETTINGS });
+      settingsRow = { userId, settings: DEFAULT_SETTINGS, updatedAt: new Date() };
+    }
+    return NextResponse.json({ settings: settingsRow.settings });
+  } catch (error) {
+    console.error('Error fetching user settings:', error);
+    return NextResponse.json({ error: 'Failed to fetch settings' }, { status: 500 });
   }
-  return NextResponse.json({ settings: settingsRow.settings });
 }
 
 export async function POST(req: Request) {
-  const { userId } = await getAuth();
+  const { userId } = await auth();
   if (!userId) {
-    return NextResponse.json({ code: 'UNAUTHORIZED', message: 'You must be logged in to update user settings' }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const body = await req.json();
-  const newSettings = body.settings;
-  if (!newSettings || typeof newSettings !== 'object') {
-    return NextResponse.json({ code: 'BAD_REQUEST', message: 'Invalid settings' }, { status: 400 });
+  
+  try {
+    const body = await req.json();
+    const newSettings = body.settings;
+    if (!newSettings || typeof newSettings !== 'object') {
+      return NextResponse.json({ error: 'Invalid settings' }, { status: 400 });
+    }
+    
+    // Upsert settings
+    await db
+      .insert(userSettings)
+      .values({ userId, settings: newSettings })
+      .onConflictDoUpdate({
+        target: userSettings.userId,
+        set: { settings: newSettings, updatedAt: new Date() },
+      });
+    return NextResponse.json({ status: 'success' });
+  } catch (error) {
+    console.error('Error updating user settings:', error);
+    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
   }
-  // Upsert settings
-  await db
-    .insert(userSettings)
-    .values({ userId, settings: newSettings })
-    .onConflictDoUpdate({
-      target: userSettings.userId,
-      set: { settings: newSettings, updatedAt: new Date() },
-    });
-  return NextResponse.json({ status: 'success' });
 }

--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -33,14 +33,14 @@ export async function POST(req: Request) {
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  
+
   try {
     const body = await req.json();
     const newSettings = body.settings;
     if (!newSettings || typeof newSettings !== 'object') {
       return NextResponse.json({ error: 'Invalid settings' }, { status: 400 });
     }
-    
+
     // Upsert settings
     await db
       .insert(userSettings)

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,6 +30,14 @@ export default clerkMiddleware(async (auth, req) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   };
 
+  // Protect /api/user routes
+  if (req.nextUrl.pathname.startsWith('/api/user')) {
+    const resolvedAuth = await auth();
+    if (!resolvedAuth.userId) {
+      return returnUnauthorized();
+    }
+  }
+
   // Protect all other /api/templates routes (POST, PUT, DELETE)
   if (req.nextUrl.pathname.startsWith('/api/templates')) {
     const resolvedAuth = await auth();
@@ -85,7 +93,6 @@ export const config = {
   matcher: [
     '/api/templates/:path*',
     '/api/user/:path*',
-
     '/api/patient-sessions/:path*',
     '/api/mobile/:path*',
     '/api/ably/:path*',

--- a/src/features/consultation/components/CurrentSessionBar.tsx
+++ b/src/features/consultation/components/CurrentSessionBar.tsx
@@ -84,7 +84,7 @@ export const CurrentSessionBar: React.FC<CurrentSessionBarProps> = ({
       // Generate a new patient name with current timestamp
       const now = new Date();
       const patientName = `Patient ${now.toLocaleDateString()} ${now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
-      
+
       // Create new patient session
       const newSession = await createPatientSession(patientName);
       if (!newSession) {

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -91,7 +91,7 @@ export const Header = () => {
           </button>
           {isSignedIn
             ? (
-                <UserButton afterSignOutUrl="/" />
+                <UserButton />
               )
             : (
                 <div className="space-x-2">

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -202,7 +202,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   ${isCollapsed ? 'justify-center' : ''}
                 `}
                     >
-                      <UserButton afterSignOutUrl="/" />
+                      <UserButton />
                       {!isCollapsed && <span className="text-sm text-slate-600">Account</span>}
                     </div>
                   )

--- a/src/shared/components/ui/dropdown-menu.tsx
+++ b/src/shared/components/ui/dropdown-menu.tsx
@@ -33,7 +33,7 @@ export function DropdownMenuTrigger({ children }: { children: React.ReactNode })
           ctx.setOpen(!ctx.open);
         }
       }}
-             className="cursor-pointer focus:outline-none"
+      className="cursor-pointer focus:outline-none"
       role="button"
       tabIndex={0}
     >


### PR DESCRIPTION
Standardize Clerk authentication and fix API route imports to resolve 500 errors and React hydration issues.

The user experienced 500 errors on API endpoints and a React hydration error (#418) after a major RBAC update and upgrading Clerk. Investigation revealed that API routes were using inconsistent authentication methods (some `getAuth()`, some direct `auth()`), deprecated Clerk `afterSignOutUrl` props were present, and some API routes had incorrect relative import paths for database client and schema. This PR standardizes authentication to use `auth()` directly, removes the deprecated Clerk prop, corrects import paths, and enhances middleware to explicitly protect `/api/user` routes, ensuring consistent and correct authentication state across the application.